### PR TITLE
add roundcommon sub for rounding away from zero

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for Format-Util
 
 {{$NEXT}}
 
+0.12      2017-06-15 02:58:10+00:00 UTC
+    add sub roundcommon for better standard rounding
+
 0.11      2017-06-09 07:18:17+00:00 UTC
     add sub to get precision config, add ETC, LTC precision
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -42,7 +42,7 @@ my %WriteMakefileArgs = (
     "Test::More" => "0.94",
     "Test::NoWarnings" => 0
   },
-  "VERSION" => "0.11",
+  "VERSION" => "0.12",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/lib/Format/Util.pm
+++ b/lib/Format/Util.pm
@@ -10,7 +10,7 @@ Format::Util - Miscellaneous routines to do with manipulating with strings and n
 
 =cut
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 
 =head1 SYNOPSIS
 

--- a/lib/Format/Util/Numbers.pm
+++ b/lib/Format/Util/Numbers.pm
@@ -271,7 +271,7 @@ sub roundcommon {
             not defined $val
             or $val !~ $floating_point_regex
         )
-        or (not defined $precision or $precision !~ /i^(?:1(?:[eE][-]?[0-9]+)?|0(?:\.0*1)?)$/ or $precision == 0));
+        or (not defined $precision or $precision !~ /^(?:1(?:[eE][-]?[0-9]+)?|0(?:\.0*1)?)$/ or $precision == 0));
 
     # get the number of decimal places needed by BigFloat
     $precision = log(1 / $precision) / log(10);

--- a/lib/Format/Util/Numbers.pm
+++ b/lib/Format/Util/Numbers.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings FATAL => 'all';
 
 use base 'Exporter';
-our @EXPORT_OK = qw/commas to_monetary_number_format roundnear financialrounding formatnumber/;
+our @EXPORT_OK = qw/commas to_monetary_number_format roundnear roundcommon financialrounding formatnumber/;
 
 use Carp qw(cluck);
 use Scalar::Util qw(looks_like_number);
@@ -229,17 +229,54 @@ sub financialrounding {
         or not defined $precisions->{$type // 'unknown-type'}
         or not defined $precisions->{$type}->{$currency // 'unknown-type'});
 
-    # get current global mode
-    my $current_mode = Math::BigFloat->round_mode();
-    Math::BigFloat->round_mode('common');
+    return _round_to_precison($precisions->{$type}->{$currency}, $val);
+}
 
-    my $x = Math::BigFloat->new($val)->bfround('-' . $precisions->{$type}->{$currency});
-    $x = $x->numify();
+=head2 roundcommon
 
-    # set back to origianl mode
-    Math::BigFloat->round_mode($current_mode);
+This sub rounds number as per precision passed, this sub
+should be used for numbers not related to currencies like
+probabilities, percentages etc
 
-    return $x;
+This sub use round away from zero technique, same as
+financial rounding, the only difference is it acccepts
+precision as shown below and has no currency precision
+
+Acceptable precision values format example:
+
+0
+1
+1e-4
+0.0001
+
+This sub only supports rounding to one tenths, hundredths,
+thousandths and so on. It does not support rounding to two,
+three tenths, hundredths or so, use roundnear for that.
+
+This sub is created as replacement for roundnear as roundnear
+for small numbers it does round away from zero,
+for numbers with more significant digits it's sort-of random
+
+Returns number
+
+    roundcommon(0.01, 10.234) => 10.23
+
+=cut
+
+sub roundcommon {
+    my ($precision, $val) = @_;
+
+    return $val
+        if ((
+            not defined $val
+            or $val !~ $floating_point_regex
+        )
+        or (not defined $precision or $precision !~ /^(?:1(?:[eE][-]?[0-9])?|0(?:\.0+1)?)$/ or $precision == 0));
+
+    # get the number of decimal places needed by BigFloat
+    $precision = log(1 / $precision) / log(10);
+
+    return _round_to_precison($precision, $val);
 }
 
 =head2 get_precision_config
@@ -250,6 +287,23 @@ This is used get complete currency precision config.
 
 sub get_precision_config {
     return $precisions;
+}
+
+# common sub used by roundcommon and financialrounding
+sub _round_to_precison {
+    my ($precision, $val) = @_;
+
+    # get current global mode
+    my $current_mode = Math::BigFloat->round_mode();
+    Math::BigFloat->round_mode('common');
+
+    my $x = Math::BigFloat->new($val)->bfround('-' . $precision);
+    $x = $x->numify();
+
+    # set back to origianl mode
+    Math::BigFloat->round_mode($current_mode);
+
+    return $x;
 }
 
 =head1 AUTHOR

--- a/lib/Format/Util/Numbers.pm
+++ b/lib/Format/Util/Numbers.pm
@@ -271,7 +271,7 @@ sub roundcommon {
             not defined $val
             or $val !~ $floating_point_regex
         )
-        or (not defined $precision or $precision !~ /^(?:1(?:[eE][-]?[0-9])?|0(?:\.0+1)?)$/ or $precision == 0));
+        or (not defined $precision or $precision !~ /i^(?:1(?:[eE][-]?[0-9]+)?|0(?:\.0*1)?)$/ or $precision == 0));
 
     # get the number of decimal places needed by BigFloat
     $precision = log(1 / $precision) / log(10);

--- a/t/Numbers.t
+++ b/t/Numbers.t
@@ -19,14 +19,16 @@ subtest 'roundnear' => sub {
 subtest 'roundcommon' => sub {
     cmp_ok(roundcommon(0,    345.56789), '==', 345.56789, 'No rounding is correct.');
     cmp_ok(roundcommon(1,    345.56789), '==', 346,       'Ones is correct.');
+    cmp_ok(roundcommon(0.1,  345.56789), '==', 345.6,     'Correct rounding for 1 decimal place');
     cmp_ok(roundcommon(0.01, 345.56789), '==', 345.57,    'Hundredths rounding is correct.');
     cmp_ok(roundcommon(0.02, 345.56789), '==', 345.56789, 'Two hundredths rounding is not supported.');
-    cmp_ok(roundcommon(10,   345.56789), '==', 345.56789, 'Rounding supported till 10 digits.');
+    cmp_ok(roundcommon(10,   345.56789), '==', 345.56789, 'Not supported, only supported integer is 1');
     is(roundcommon(0, undef), undef, 'Rounding undef yields undef.');
-    cmp_ok(roundcommon(1e-2,  10.456), '==', 10.46,  'Rounding with exponential precision');
-    cmp_ok(roundcommon(-1e-2, 10.456), '==', 10.456, 'incorrect precision returns same value back');
-    cmp_ok(roundcommon(0.01,  0.025),  '==', 0.03,   'Correct rounding, round away from zero');
-    cmp_ok(roundcommon(0.01,  -0.025), '==', -0.03,  'Correct rounding, round away from zero');
+    cmp_ok(roundcommon(1e-2,  10.456),            '==', 10.46,         'Rounding with exponential precision');
+    cmp_ok(roundcommon(-1e-2, 10.456),            '==', 10.456,        'incorrect precision returns same value back');
+    cmp_ok(roundcommon(1e-10, 10.56783333331239), '==', 10.5678333333, 'Rounding with exponential precision');
+    cmp_ok(roundcommon(0.01,  0.025),             '==', 0.03,          'Correct rounding, round away from zero');
+    cmp_ok(roundcommon(0.01,  -0.025),            '==', -0.03,         'Correct rounding, round away from zero');
 };
 
 subtest 'commas' => sub {

--- a/t/Numbers.t
+++ b/t/Numbers.t
@@ -1,135 +1,164 @@
 use strict;
 use warnings;
 
-use Test::More tests => 495;
+use Test::More tests => 9;
 use Test::Exception;
 use Test::NoWarnings;
 
-use Format::Util::Numbers qw(roundnear commas to_monetary_number_format formatnumber financialrounding);
+use Format::Util::Numbers qw(roundnear roundcommon commas to_monetary_number_format formatnumber financialrounding);
 
-is(roundnear(0,    345.56789), 345.56789, 'No rounding is correct.');
-is(roundnear(1,    345.56789), 346,       'Ones is correct.');
-is(roundnear(0.01, 345.56789), 345.57,    'Hundredths rounding is correct.');
-is(roundnear(0.02, 345.56789), 345.56,    'Two hundredths rounding is correct.');
-is(roundnear(10,   345.56789), 350,       'No rounding is correct.');
-is(roundnear(0,    undef),     undef,     'Rounding undef yields undef.');
+subtest 'roundnear' => sub {
+    is(roundnear(0,    345.56789), 345.56789, 'No rounding is correct.');
+    is(roundnear(1,    345.56789), 346,       'Ones is correct.');
+    is(roundnear(0.01, 345.56789), 345.57,    'Hundredths rounding is correct.');
+    is(roundnear(0.02, 345.56789), 345.56,    'Two hundredths rounding is correct.');
+    is(roundnear(10,   345.56789), 350,       'No rounding is correct.');
+    is(roundnear(0,    undef),     undef,     'Rounding undef yields undef.');
+};
 
-is(commas(12345.6789, 0), '12,346',      '0 decimal commas is correct');
-is(commas(12345.6789, 1), '12,345.7',    '1 decimal commas is correct');
-is(commas(12345.6789, 2), '12,345.68',   '2 decimal commas is correct');
-is(commas(12345.6789, 3), '12,345.679',  '3 decimal commas is correct');
-is(commas(12345.6789, 4), '12,345.6789', '4 decimal commas is correct');
+subtest 'roundcommon' => sub {
+    cmp_ok(roundcommon(0,    345.56789), '==', 345.56789, 'No rounding is correct.');
+    cmp_ok(roundcommon(1,    345.56789), '==', 346,       'Ones is correct.');
+    cmp_ok(roundcommon(0.01, 345.56789), '==', 345.57,    'Hundredths rounding is correct.');
+    cmp_ok(roundcommon(0.02, 345.56789), '==', 345.56789, 'Two hundredths rounding is not supported.');
+    cmp_ok(roundcommon(10,   345.56789), '==', 345.56789, 'Rounding supported till 10 digits.');
+    is(roundcommon(0, undef), undef, 'Rounding undef yields undef.');
+    cmp_ok(roundcommon(1e-2,  10.456), '==', 10.46,  'Rounding with exponential precision');
+    cmp_ok(roundcommon(-1e-2, 10.456), '==', 10.456, 'incorrect precision returns same value back');
+    cmp_ok(roundcommon(0.01,  0.025),  '==', 0.03,   'Correct rounding, round away from zero');
+    cmp_ok(roundcommon(0.01,  -0.025), '==', -0.03,  'Correct rounding, round away from zero');
+};
 
-is(commas(12345.00, 0), '12,345',    '0 decimal commas is correct');
-is(commas(12345,    0), '12,345',    '0 decimal commas is correct');
-is(commas(1234567,  0), '1,234,567', 'integer value >1m is correct');
-is(commas(1234567), '1,234,567', 'integer value >1m with no DP parameter is correct');
-is(commas(1234567.89, 2), '1,234,567.89', 'floating point value >1m is correct');
+subtest 'commas' => sub {
+    is(commas(12345.6789, 0), '12,346',      '0 decimal commas is correct');
+    is(commas(12345.6789, 1), '12,345.7',    '1 decimal commas is correct');
+    is(commas(12345.6789, 2), '12,345.68',   '2 decimal commas is correct');
+    is(commas(12345.6789, 3), '12,345.679',  '3 decimal commas is correct');
+    is(commas(12345.6789, 4), '12,345.6789', '4 decimal commas is correct');
 
-is(commas('N/A',    4), 'N/A',        'Non-numeric commas returns same');
-is(commas(.0004,    0), '0',          'Virgule does not produce -0');
-is(commas(100.34,   1), 100.3,        'Virgule fine with smaller numbers');
-is(commas(-1234.56, 3), '-1,234.560', 'Virgule on negatives is fine');
-is(commas(-1234.56, 1), '-1,234.6',   'Virgule does not round down toward zero');
+    is(commas(12345.00, 0), '12,345',    '0 decimal commas is correct');
+    is(commas(12345,    0), '12,345',    '0 decimal commas is correct');
+    is(commas(1234567,  0), '1,234,567', 'integer value >1m is correct');
+    is(commas(1234567), '1,234,567', 'integer value >1m with no DP parameter is correct');
+    is(commas(1234567.89, 2), '1,234,567.89', 'floating point value >1m is correct');
 
-is(to_monetary_number_format(undef),     '0.00',           'undef to_monetary_number_format is correct');
-is(to_monetary_number_format('N/A'),     'N/A',            'nonnumeric to_monetary_number_format is correct');
-is(to_monetary_number_format(123456789), '123,456,789.00', 'Integer to_monetary_number_format is correct');
-is(to_monetary_number_format(123456789, 1), '123,456,789', 'Integer to_monetary_number_format is correct when requested to remove int decimals');
-is(to_monetary_number_format(12345678.9), '12,345,678.90', 'One decimal to_monetary_number_format is correct');
-is(to_monetary_number_format(12345678.9, 1),
-    '12,345,678.90', 'One decimal to_monetary_number_format is correct when requested to remove int decimals');
-is(to_monetary_number_format(1234567.89), '1,234,567.89', 'Two decimal to_monetary_number_format is correct');
-is(to_monetary_number_format(123456.789), '123,456.79',   'Three to_monetary_number_format is correct');
+    is(commas('N/A',    4), 'N/A',        'Non-numeric commas returns same');
+    is(commas(.0004,    0), '0',          'Virgule does not produce -0');
+    is(commas(100.34,   1), 100.3,        'Virgule fine with smaller numbers');
+    is(commas(-1234.56, 3), '-1,234.560', 'Virgule on negatives is fine');
+    is(commas(-1234.56, 1), '-1,234.6',   'Virgule does not round down toward zero');
+};
 
-is(to_monetary_number_format(-4567.89), '-4,567.89', 'negative number to_monetary_number_format is correct');
-is(to_monetary_number_format(-456.789), '-456.79',   'negative number to_monetary_number_format is correct, no leading ","');
-is(to_monetary_number_format(-56.7),    '-56.70',    'negative number to_monetary_number_format is correct, add 2 decimal places');
+subtest 'to_monetary_number_format' => sub {
+    is(to_monetary_number_format(undef),     '0.00',           'undef to_monetary_number_format is correct');
+    is(to_monetary_number_format('N/A'),     'N/A',            'nonnumeric to_monetary_number_format is correct');
+    is(to_monetary_number_format(123456789), '123,456,789.00', 'Integer to_monetary_number_format is correct');
+    is(to_monetary_number_format(123456789, 1), '123,456,789', 'Integer to_monetary_number_format is correct when requested to remove int decimals');
+    is(to_monetary_number_format(12345678.9), '12,345,678.90', 'One decimal to_monetary_number_format is correct');
+    is(to_monetary_number_format(12345678.9, 1),
+        '12,345,678.90', 'One decimal to_monetary_number_format is correct when requested to remove int decimals');
+    is(to_monetary_number_format(1234567.89), '1,234,567.89', 'Two decimal to_monetary_number_format is correct');
+    is(to_monetary_number_format(123456.789), '123,456.79',   'Three to_monetary_number_format is correct');
 
-is formatnumber('amount', 'USD'), undef, 'undef number comes back same, no formatting done';
-is formatnumber('amount',  'USD', 'abc'), 'abc', 'invalid number comes back same, no formatting done';
-is formatnumber('amount',  'USD', '+.'),  '+.',  'invalid number comes back same, no formatting done';
-is formatnumber('invalid', 'USD', 10),    '10',  'invalid precision type sends back the same value';
-is formatnumber('amount',  'FOO', 10),    '10',  'invalid currency type sends back the same value';
+    is(to_monetary_number_format(-4567.89), '-4,567.89', 'negative number to_monetary_number_format is correct');
+    is(to_monetary_number_format(-456.789), '-456.79',   'negative number to_monetary_number_format is correct, no leading ","');
+    is(to_monetary_number_format(-56.7),    '-56.70',    'negative number to_monetary_number_format is correct, add 2 decimal places');
+};
 
-is formatnumber('amount', 'USD', 10.345),  '10.35',  'Changed the input number';
-is formatnumber('amount', 'USD', -10.345), '-10.35', 'Changed the input number';
-is formatnumber('amount', 'USD', 10.344),  '10.34',  'trimmed the input number';
-is formatnumber('amount', 'EUR', 10.394),  '10.39',  'trimmed the input number';
-is formatnumber('amount', 'JPY', 10.398),  '10.40',  'Changed the input number';
-is formatnumber('amount', 'AUD', -10.398), '-10.40', 'Changed the input number';
+subtest 'formatnumber' => sub {
+    is formatnumber('amount', 'USD'), undef, 'undef number comes back same, no formatting done';
+    is formatnumber('amount',  'USD', 'abc'), 'abc', 'invalid number comes back same, no formatting done';
+    is formatnumber('amount',  'USD', '+.'),  '+.',  'invalid number comes back same, no formatting done';
+    is formatnumber('invalid', 'USD', 10),    '10',  'invalid precision type sends back the same value';
+    is formatnumber('amount',  'FOO', 10),    '10',  'invalid currency type sends back the same value';
 
-is formatnumber('amount', 'USD', 10),               '10.00',       'USD 10 -> 10.00';
-is formatnumber('amount', 'USD', 10.000001),        '10.00',       'USD 10.000001 -> 10.00';
-is formatnumber('amount', 'EUR', 10.000001),        '10.00',       'EUR 10.000001 -> 10.00';
-is formatnumber('amount', 'JPY', 10.000001),        '10.00',       'JPY 10.000001 -> 10.00';
-is formatnumber('amount', 'BTC', 10),               '10.00000000', 'BTC 10 -> 10.00000000';
-is formatnumber('amount', 'BTC', 10.000001),        '10.00000100', 'BTC 10.000001 -> 10.00000100';
-is formatnumber('amount', 'BTC', 10.0000000000001), '10.00000000', 'BTC 10.0000000000001 -> 10.00000000';
-is formatnumber('amount', 'ETH', 10),               '10.00000000', 'ETH 10 -> 10.00000000';
-is formatnumber('amount', 'ETH', 10.000001),        '10.00000100', 'ETH 10.000001 -> 10.00000100';
-is formatnumber('amount', 'ETH', 10.0000000000001), '10.00000000', 'ETH 10.0000000000001 -> 10.00000000';
+    is formatnumber('amount', 'USD', 10.345),  '10.35',  'Changed the input number';
+    is formatnumber('amount', 'USD', -10.345), '-10.35', 'Changed the input number';
+    is formatnumber('amount', 'USD', 10.344),  '10.34',  'trimmed the input number';
+    is formatnumber('amount', 'EUR', 10.394),  '10.39',  'trimmed the input number';
+    is formatnumber('amount', 'JPY', 10.398),  '10.40',  'Changed the input number';
+    is formatnumber('amount', 'AUD', -10.398), '-10.40', 'Changed the input number';
 
-is financialrounding('amount', 'USD'), undef, 'undef number comes back same, no formatting done';
-is financialrounding('amount', 'USD', 'abc'), 'abc', 'invalid number comes back same, no formatting done';
-is financialrounding('amount', 'USD', '+.'),  '+.',  'invalid number comes back same, no formatting done';
-cmp_ok financialrounding('invalid', 'USD', 10), '==', 10, 'invalid precision type sends back the same value';
-cmp_ok financialrounding('amount',  'FOO', 10), '==', 10, 'invalid currency type sends back the same value';
+    is formatnumber('amount', 'USD', 10),               '10.00',       'USD 10 -> 10.00';
+    is formatnumber('amount', 'USD', 10.000001),        '10.00',       'USD 10.000001 -> 10.00';
+    is formatnumber('amount', 'EUR', 10.000001),        '10.00',       'EUR 10.000001 -> 10.00';
+    is formatnumber('amount', 'JPY', 10.000001),        '10.00',       'JPY 10.000001 -> 10.00';
+    is formatnumber('amount', 'BTC', 10),               '10.00000000', 'BTC 10 -> 10.00000000';
+    is formatnumber('amount', 'BTC', 10.000001),        '10.00000100', 'BTC 10.000001 -> 10.00000100';
+    is formatnumber('amount', 'BTC', 10.0000000000001), '10.00000000', 'BTC 10.0000000000001 -> 10.00000000';
+    is formatnumber('amount', 'ETH', 10),               '10.00000000', 'ETH 10 -> 10.00000000';
+    is formatnumber('amount', 'ETH', 10.000001),        '10.00000100', 'ETH 10.000001 -> 10.00000100';
+    is formatnumber('amount', 'ETH', 10.0000000000001), '10.00000000', 'ETH 10.0000000000001 -> 10.00000000';
+};
 
-cmp_ok financialrounding('amount', 'USD', 10.345),  '==', 10.35,  'Changed the input number';
-cmp_ok financialrounding('amount', 'USD', 10.344),  '==', 10.34,  'Changed the input number';
-cmp_ok financialrounding('amount', 'USD', 10.394),  '==', 10.39,  'trimmed the input number';
-cmp_ok financialrounding('amount', 'USD', -10.394), '==', -10.39, 'trimmed the input number';
-cmp_ok financialrounding('amount', 'USD', 10.398),  '==', 10.40,  'Changed the input number';
-cmp_ok financialrounding('amount', 'USD', -10.398), '==', -10.40, 'Changed the input number';
+subtest 'financialrounding' => sub {
+    is financialrounding('amount', 'USD'), undef, 'undef number comes back same, no formatting done';
+    is financialrounding('amount', 'USD', 'abc'), 'abc', 'invalid number comes back same, no formatting done';
+    is financialrounding('amount', 'USD', '+.'),  '+.',  'invalid number comes back same, no formatting done';
+    cmp_ok financialrounding('invalid', 'USD', 10), '==', 10, 'invalid precision type sends back the same value';
+    cmp_ok financialrounding('amount',  'FOO', 10), '==', 10, 'invalid currency type sends back the same value';
 
-cmp_ok financialrounding('amount', 'USD', 10),               '==', 10,        'USD 10 -> 10.00';
-cmp_ok financialrounding('amount', 'USD', 10.000001),        '==', 10,        'USD 10.000001 -> 10.00';
-cmp_ok financialrounding('amount', 'EUR', 10.000001),        '==', 10,        'EUR 10.000001 -> 10.00';
-cmp_ok financialrounding('amount', 'JPY', 10.000001),        '==', 10,        'JPY 10.000001 -> 10.00';
-cmp_ok financialrounding('amount', 'BTC', 10),               '==', 10,        'BTC 10 -> 10.00000000';
-cmp_ok financialrounding('amount', 'BTC', 10.000001),        '==', 10.000001, 'BTC 10.000001 -> 10.00000100';
-cmp_ok financialrounding('amount', 'BTC', 10.0000000000001), '==', 10,        'BTC 10.0000000000001 -> 10.00000000';
-cmp_ok financialrounding('amount', 'BTC', 0.0000000650001),  '==', 0.00000007,
-    'BTC 0.000000065 -> 0.00000007 changed the number to higher value, need to be careful with this';
-cmp_ok financialrounding('amount', 'ETH', 10),               '==', 10,        'ETH 10 -> 10.00000000';
-cmp_ok financialrounding('amount', 'ETH', 10.000001),        '==', 10.000001, 'ETH 10.000001 -> 10.00000100';
-cmp_ok financialrounding('amount', 'ETH', 10.0000000000001), '==', 10,        'ETH 10.0000000000001 -> 10.00000000';
-cmp_ok financialrounding('amount', 'ETH', 0.0000000650001),  '==', 0.00000007,
-    'ETH 0.000000065 -> 0.00000007 changed the number to higher value, need to be careful with this';
+    cmp_ok financialrounding('amount', 'USD', 10.345),  '==', 10.35,  'Changed the input number';
+    cmp_ok financialrounding('amount', 'USD', 10.344),  '==', 10.34,  'Changed the input number';
+    cmp_ok financialrounding('amount', 'USD', 10.394),  '==', 10.39,  'trimmed the input number';
+    cmp_ok financialrounding('amount', 'USD', -10.394), '==', -10.39, 'trimmed the input number';
+    cmp_ok financialrounding('amount', 'USD', 10.398),  '==', 10.40,  'Changed the input number';
+    cmp_ok financialrounding('amount', 'USD', -10.398), '==', -10.40, 'Changed the input number';
 
+    cmp_ok financialrounding('amount', 'USD', 10),               '==', 10,        'USD 10 -> 10.00';
+    cmp_ok financialrounding('amount', 'USD', 10.000001),        '==', 10,        'USD 10.000001 -> 10.00';
+    cmp_ok financialrounding('amount', 'EUR', 10.000001),        '==', 10,        'EUR 10.000001 -> 10.00';
+    cmp_ok financialrounding('amount', 'JPY', 10.000001),        '==', 10,        'JPY 10.000001 -> 10.00';
+    cmp_ok financialrounding('amount', 'BTC', 10),               '==', 10,        'BTC 10 -> 10.00000000';
+    cmp_ok financialrounding('amount', 'BTC', 10.000001),        '==', 10.000001, 'BTC 10.000001 -> 10.00000100';
+    cmp_ok financialrounding('amount', 'BTC', 10.0000000000001), '==', 10,        'BTC 10.0000000000001 -> 10.00000000';
+    cmp_ok financialrounding('amount', 'BTC', 0.0000000650001),  '==', 0.00000007,
+        'BTC 0.000000065 -> 0.00000007 changed the number to higher value, need to be careful with this';
+    cmp_ok financialrounding('amount', 'ETH', 10),               '==', 10,        'ETH 10 -> 10.00000000';
+    cmp_ok financialrounding('amount', 'ETH', 10.000001),        '==', 10.000001, 'ETH 10.000001 -> 10.00000100';
+    cmp_ok financialrounding('amount', 'ETH', 10.0000000000001), '==', 10,        'ETH 10.0000000000001 -> 10.00000000';
+    cmp_ok financialrounding('amount', 'ETH', 0.0000000650001),  '==', 0.00000007,
+        'ETH 0.000000065 -> 0.00000007 changed the number to higher value, need to be careful with this';
+    cmp_ok(financialrounding('amount', 'USD', 0.025),  '==', 0.03,  'Correct rounding, round away from zero');
+    cmp_ok(financialrounding('amount', 'USD', -0.025), '==', -0.03, 'Correct rounding, round away from zero');
+};
+
+subtest 'regression' => sub {
 # Now we just want to make sure that it works with all kinds of inputs, so we'll sort of fuzz test it.
-foreach my $i (1 .. 100) {
-    my $j = rand() * rand(100000);
-    cmp_ok(roundnear(1 / $i, $j), '>=', 0, 'roundnear runs for (' . 1 / $i . ',' . $j . ')');
-    ok(commas($j, $i), 'commas runs for (' . $j . ',' . $i . ')');
-    ok(to_monetary_number_format($j), 'to_monetary_number_format runs for (' . $j . ')');
-}
+    foreach my $i (1 .. 100) {
+        my $j = rand() * rand(100000);
+        cmp_ok(roundnear(1 / $i, $j), '>=', 0, 'roundnear runs for (' . 1 / $i . ',' . $j . ')');
+        ok(commas($j, $i), 'commas runs for (' . $j . ',' . $i . ')');
+        ok(to_monetary_number_format($j), 'to_monetary_number_format runs for (' . $j . ')');
+    }
 
-foreach my $i (-100 .. -1) {
-    my $j = rand() * rand(-100000);
-    cmp_ok(roundnear(1 / $i, $j), '<=', 0, 'roundnear runs for (' . 1 / $i . ',' . $j . ')');
-}
+    foreach my $i (-100 .. -1) {
+        my $j = rand() * rand(-100000);
+        cmp_ok(roundnear(1 / $i, $j), '<=', 0, 'roundnear runs for (' . 1 / $i . ',' . $j . ')');
+    }
+};
 
+subtest 'precision' => sub {
 # Test default precisions
-my $precisions = Format::Util::Numbers::get_precision_config();
+    my $precisions = Format::Util::Numbers::get_precision_config();
 
-is $precisions->{amount}->{USD}, '2', 'Correct amount precision for USD';
-is $precisions->{amount}->{EUR}, '2', 'Correct amount precision for EUR';
-is $precisions->{amount}->{GBP}, '2', 'Correct amount precision for GBP';
-is $precisions->{amount}->{AUD}, '2', 'Correct amount precision for AUD';
-is $precisions->{amount}->{JPY}, '2', 'Correct amount precision for JPY';
-is $precisions->{amount}->{BTC}, '8', 'Correct amount precision for BTC';
-is $precisions->{amount}->{LTC}, '8', 'Correct amount precision for LTC';
-is $precisions->{amount}->{ETH}, '8', 'Correct amount precision for ETH';
-is $precisions->{amount}->{ETC}, '8', 'Correct amount precision for ETC';
+    is $precisions->{amount}->{USD}, '2', 'Correct amount precision for USD';
+    is $precisions->{amount}->{EUR}, '2', 'Correct amount precision for EUR';
+    is $precisions->{amount}->{GBP}, '2', 'Correct amount precision for GBP';
+    is $precisions->{amount}->{AUD}, '2', 'Correct amount precision for AUD';
+    is $precisions->{amount}->{JPY}, '2', 'Correct amount precision for JPY';
+    is $precisions->{amount}->{BTC}, '8', 'Correct amount precision for BTC';
+    is $precisions->{amount}->{LTC}, '8', 'Correct amount precision for LTC';
+    is $precisions->{amount}->{ETH}, '8', 'Correct amount precision for ETH';
+    is $precisions->{amount}->{ETC}, '8', 'Correct amount precision for ETC';
 
-is $precisions->{price}->{USD}, '2', 'Correct price precision for USD';
-is $precisions->{price}->{EUR}, '2', 'Correct price precision for EUR';
-is $precisions->{price}->{GBP}, '2', 'Correct price precision for GBP';
-is $precisions->{price}->{AUD}, '2', 'Correct price precision for AUD';
-is $precisions->{price}->{JPY}, '0', 'Correct price precision for JPY';
-is $precisions->{price}->{BTC}, '8', 'Correct price precision for BTC';
-is $precisions->{price}->{LTC}, '8', 'Correct price precision for LTC';
-is $precisions->{price}->{ETH}, '8', 'Correct price precision for ETH';
-is $precisions->{price}->{ETC}, '8', 'Correct price precision for ETC';
+    is $precisions->{price}->{USD}, '2', 'Correct price precision for USD';
+    is $precisions->{price}->{EUR}, '2', 'Correct price precision for EUR';
+    is $precisions->{price}->{GBP}, '2', 'Correct price precision for GBP';
+    is $precisions->{price}->{AUD}, '2', 'Correct price precision for AUD';
+    is $precisions->{price}->{JPY}, '0', 'Correct price precision for JPY';
+    is $precisions->{price}->{BTC}, '8', 'Correct price precision for BTC';
+    is $precisions->{price}->{LTC}, '8', 'Correct price precision for LTC';
+    is $precisions->{price}->{ETH}, '8', 'Correct price precision for ETH';
+    is $precisions->{price}->{ETC}, '8', 'Correct price precision for ETC';
+};


### PR DESCRIPTION
roundnear has buggy implementation so this acts as replacement for
that. roundnear is kept for backward compatiblity

```
perl -MFormat::Util::Numbers=roundnear -le 'print roundnear 0.01, $_ for
(@ARGV)' 0.025 1.005 1.015 1.025 1.035 72456245.005 72456245.015
72456245.025 72456245.035 1.003
0.03
1.01 -> rounds away from zero
1.02
1.03
1.04
72456245 -> round towards zero
72456245.01
72456245.03
72456245.03
1
```

This will use Math::BigFloat common rounding as thats more consistent

```
perl -MMath::BigFloat -le 'print Math::BigFloat->new($_)->bfround(-2)
for (@ARGV)' 0.025 1.005 1.015 1.025 1.035 72456245.005 72456245.015
72456245.025 72456245.035 1.003
0.02
1.00
1.02
1.02
1.04
72456245.00
72456245.02
72456245.02
72456245.04
1.00
```