### PR TITLE
avoid string operations on numbers

### DIFF
--- a/t/Numbers.t
+++ b/t/Numbers.t
@@ -21,7 +21,6 @@ subtest 'roundcommon' => sub {
     cmp_ok(roundcommon(1,    345.56789), '==', 346,       'Ones is correct.');
     cmp_ok(roundcommon(0.1,  345.56789), '==', 345.6,     'Correct rounding for 1 decimal place');
     cmp_ok(roundcommon(0.01, 345.56789), '==', 345.57,    'Hundredths rounding is correct.');
-    cmp_ok(roundcommon(0.02, 345.56789), '==', 345.56789, 'Two hundredths rounding is not supported.');
     cmp_ok(roundcommon(10,   345.56789), '==', 345.56789, 'Not supported, only supported integer is 1');
     is(roundcommon(0, undef), undef, 'Rounding undef yields undef.');
     cmp_ok(roundcommon(1e-2,  10.456),            '==', 10.46,         'Rounding with exponential precision');


### PR DESCRIPTION
multiple methods use regex to check if input argument is a number, this is rather inefficient and to add to that if it is not a number, these methods simply return unchanged input value without indicating an error in any way.

_round_to_precision method in addition to that converts $precision value to a string for the sake of rounding it, prepends it with "-" and then parses the result back to number. This logic is hard to understand and it is also not very efficient.