### PR TITLE
config/opt_662_xrp_payout_currency

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Format-Util
 
 {{$NEXT}}
 
+    - Add XRP to precision.yml
+
 0.17      2022-10-18 01:38:02+00:00 UTC
     - Add tUSDT
 

--- a/share/precision.yml
+++ b/share/precision.yml
@@ -179,6 +179,7 @@ price:
   XCD: 2
   XOF: 0
   XPF: 0
+  XRP: 6
   YER: 2
   ZAR: 2
   ZMW: 2
@@ -364,6 +365,7 @@ amount:
   XCD: 2
   XOF: 2
   XPF: 2
+  XRP: 6
   YER: 2
   ZAR: 2
   ZMW: 2


### PR DESCRIPTION
# Description
To allow user to use `XRP` as payout currency.

In this card, we add `XRP` to `precision.yml` . 